### PR TITLE
Ensure `Content-Type` header is set for JSON requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ client = Bambora::Client.new(
 #### Create a Profile
 
 ```ruby
-client.profile.create(
+client.profiles.create(
   {
     language: 'en',
     comments: 'hello',
@@ -84,7 +84,7 @@ client.profile.create(
 ## Delete a Profile
 
 ```ruby
-client.profile.delete(customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A')
+client.profiles.delete(customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A')
 # => {
 #       :code => 1,
 #       :message => "Operation Successful"

--- a/README.md
+++ b/README.md
@@ -84,23 +84,11 @@ client.profile.create(
 ## Delete a Profile
 
 ```ruby
-client.profile.delete(customer_code: 'asdf1234')
+client.profile.delete(customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A')
 # => {
-#       code: 1,
-#       message: 'Hup...want...buy.',
-#       customer_code: 'asdf1234',
-#       validation: {
-#         id: '',
-#         approved: 1,
-#         message_id: 1,
-#         message: '',
-#         auth_code: '',
-#         trans_date: '',
-#         order_number: '',
-#         type: '',
-#         amount: 0,
-#         cvd_id: 123,
-#       },
+#       :code => 1,
+#       :message => "Operation Successful"
+#       :customer_code: "02355E2e58Bf488EAB4EaFAD7083dB6A",
 #    }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,33 +63,21 @@ client = Bambora::Client.new(
 ```ruby
 client.profile.create(
   {
-    'language': 'en',
-    'comments': 'hello',
-    'card':{
-      'name': 'Hup Podling',
-      'number': '4030000010001234',
-      'expiry_month': '12',
-      'expiry_year': '23',
-      'cvd': '123',
+    language: 'en',
+    comments: 'hello',
+    card: {
+      name: 'Hup Podling',
+      number: '4030000010001234',
+      expiry_month: '12',
+      expiry_year: '23',
+      cvd: '123',
     },
   },
 )
 # => {
-#       code: 1,
-#       message: 'Hup...want...buy.',
-#       customer_code: 'asdf1234',
-#       validation: {
-#         id: '',
-#         approved: 1,
-#         message_id: 1,
-#         message: '',
-#         auth_code: '',
-#         trans_date: '',
-#         order_number: '',
-#         type: '',
-#         amount: 0,
-#         cvd_id: 123,
-#       },
+#       :code => 1,
+#       :message => "Operation Successful"
+#       :customer_code: "02355E2e58Bf488EAB4EaFAD7083dB6A",
 #    }
 ```
 

--- a/bin/console
+++ b/bin/console
@@ -8,5 +8,5 @@ require 'bambora'
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-require "pry"
+require 'pry'
 Pry.start

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -3,6 +3,7 @@
 require 'base64'
 require 'excon'
 
+require 'bambora/headers'
 require 'bambora/v1/profile'
 
 module Bambora

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'base64'
+require 'excon'
+
 module Bambora
   class Client
     extend Forwardable

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -28,8 +28,8 @@ module Bambora
 
     def_delegators :connection, :request
 
-    def profile
-      @profile ||= Bambora::V1::Profile.new(self)
+    def profiles
+      @profiles ||= Bambora::V1::Profile.new(self)
     end
 
     # Summary: Create and modify payments.

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -14,6 +14,9 @@ module Bambora
       options.each do |key, value|
         instance_variable_set("@#{key}", value)
       end
+
+      @base_url = 'https://api.na.bambora.com'
+
       yield(self) if block_given?
     end
 
@@ -46,7 +49,7 @@ module Bambora
     protected
 
     def connection
-      @connection ||= Excon.new(ENV.fetch('BAMBORA_API_URL'), headers: headers)
+      @connection ||= Excon.new(@base_url, headers: headers)
     end
 
     def headers

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -3,6 +3,8 @@
 require 'base64'
 require 'excon'
 
+require 'bambora/v1/profile'
+
 module Bambora
   class Client
     extend Forwardable

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -6,7 +6,7 @@ require 'excon'
 module Bambora
   class Client
     extend Forwardable
-    attr_accessor :merchant_id, :sub_merchant_id, :api_key
+    attr_accessor :base_url, :merchant_id, :sub_merchant_id, :api_key
 
     def initialize(options = {})
       unless options[:version].nil?

--- a/lib/bambora/json_request.rb
+++ b/lib/bambora/json_request.rb
@@ -10,7 +10,14 @@ module Bambora
     end
 
     def request(method:, path:, params: {}, body: {})
-      resp = client.request(method: method, path: path, params: params, body: body.to_json.to_s)
+      resp = client.request(
+        method: method,
+        path: path,
+        params: params,
+        body: body.to_json.to_s,
+        headers: { 'Content-Type' => 'application/json' },
+      )
+
       parse_response(resp)
     rescue JSON::ParserError
       error_response(resp)

--- a/lib/bambora/v1/profile.rb
+++ b/lib/bambora/v1/profile.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'bambora/json_request'
+
 module Bambora
   module V1
     class Profile < ::Bambora::JSONRequest

--- a/spec/bambora/client_spec.rb
+++ b/spec/bambora/client_spec.rb
@@ -9,7 +9,7 @@ module Bambora
         subject { Bambora::Client.new }
 
         it 'returns a Bambora::V1::Profile' do
-          expect(subject.profile).to be_a Bambora::V1::Profile
+          expect(subject.profiles).to be_a Bambora::V1::Profile
         end
       end
 

--- a/spec/bambora/json_request_spec.rb
+++ b/spec/bambora/json_request_spec.rb
@@ -6,7 +6,7 @@ module Bambora
   describe JSONRequest do
     let(:api_key) { 'fakekey' }
     let(:merchant_id) { 1 }
-    let(:base_url) { 'https://sandbox-api.na.bambora.com' }
+    let(:base_url) { 'https://api.na.bambora.com' }
     let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5' } }
     let(:response_body) { { response: 'body', with: { objects: 'yay!' }, and: [{ arrays: 'wow!' }] } }
     let(:client) { Bambora::Client.new(api_key: api_key, merchant_id: merchant_id) }

--- a/spec/bambora/v1/profile_spec.rb
+++ b/spec/bambora/v1/profile_spec.rb
@@ -42,7 +42,7 @@ module Bambora
         end
 
         it 'posts to the Bambora API' do
-          subject.profile.create(data)
+          subject.profiles.create(data)
 
           expect(
             a_request(:post, "#{subject.base_url}/v1/profiles").with(
@@ -62,7 +62,7 @@ module Bambora
         let(:customer_code) { '02355E2e58Bf488EAB4EaFAD7083dB6A' }
 
         it 'posts to the Bambora API' do
-          subject.profile.delete(customer_code: customer_code)
+          subject.profiles.delete(customer_code: customer_code)
 
           expect(
             a_request(:delete, "#{subject.base_url}/v1/profiles/#{customer_code}").with(

--- a/spec/bambora/v1/profile_spec.rb
+++ b/spec/bambora/v1/profile_spec.rb
@@ -8,33 +8,25 @@ module Bambora
       let(:api_key) { 'fakekey' }
       let(:merchant_id) { 1 }
       let(:sub_merchant_id) { 2 }
-      let(:base_url) { 'https://api.na.bambora.com' }
       let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5', 'Sub-Merchant-ID' => sub_merchant_id } }
       let(:response_body) do
         {
           code: 1,
-          message: 'Hup...want...buy.',
-          customer_code: 'aaa111',
-          validation: {
-            id: '',
-            approved: 1,
-            message_id: 1,
-            message: '',
-            auth_code: '',
-            trans_date: '',
-            order_number: '',
-            type: '',
-            amount: 0,
-            cvd_id: 123,
-          },
+          message: 'Operation Successful',
+          customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A',
         }
       end
 
       subject { Bambora::Client.new(api_key: api_key, merchant_id: merchant_id, sub_merchant_id: sub_merchant_id) }
 
-      before { allow(ENV).to receive(:fetch).with('BAMBORA_API_URL').and_return(base_url) }
-
       describe '#create' do
+        before do
+          stub_request(:post, "#{subject.base_url}/v1/profiles").with(
+            body: data.to_json.to_s,
+            headers: headers,
+          ).to_return(body: response_body.to_json.to_s)
+        end
+
         let(:data) do
           {
             language: 'en',
@@ -49,17 +41,11 @@ module Bambora
           }
         end
 
-        before do
-          stub_request(:post, "#{base_url}/v1/profiles").with(
-            body: data.to_json.to_s,
-            headers: headers,
-          ).to_return(body: response_body.to_json.to_s)
-        end
-
-        it 'posts to the bambora api' do
+        it 'posts to the Bambora API' do
           subject.profile.create(data)
+
           expect(
-            a_request(:post, "#{base_url}/v1/profiles").with(
+            a_request(:post, "#{subject.base_url}/v1/profiles").with(
               body: data.to_json.to_s,
               headers: headers,
             ),
@@ -68,15 +54,18 @@ module Bambora
       end
 
       describe '#delete' do
-        let(:customer_code) { 'asdf1234' }
         before do
-          stub_request(:delete, "#{base_url}/v1/profiles/#{customer_code}").to_return(body: response_body.to_json.to_s)
+          stub_request(:delete, "#{subject.base_url}/v1/profiles/#{customer_code}")
+            .to_return(body: response_body.to_json.to_s)
         end
 
-        it 'posts to the bambora api' do
+        let(:customer_code) { '02355E2e58Bf488EAB4EaFAD7083dB6A' }
+
+        it 'posts to the Bambora API' do
           subject.profile.delete(customer_code: customer_code)
+
           expect(
-            a_request(:delete, "#{base_url}/v1/profiles/#{customer_code}").with(
+            a_request(:delete, "#{subject.base_url}/v1/profiles/#{customer_code}").with(
               headers: headers,
             ),
           ).to have_been_made.once

--- a/spec/bambora/v1/profile_spec.rb
+++ b/spec/bambora/v1/profile_spec.rb
@@ -8,7 +8,7 @@ module Bambora
       let(:api_key) { 'fakekey' }
       let(:merchant_id) { 1 }
       let(:sub_merchant_id) { 2 }
-      let(:base_url) { 'https://sandbox-api.na.bambora.com' }
+      let(:base_url) { 'https://api.na.bambora.com' }
       let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5', 'Sub-Merchant-ID' => sub_merchant_id } }
       let(:response_body) do
         {


### PR DESCRIPTION
**Description**

This PR adds a few dependencies to `Bambora::Client`, and ensures that a `Content-Type` header of `application/json` is set for any request made from the descendants of `JSONRequest`.

Some clean up is also made to the documentation and specs. One of the notable changes is to update the `/profiles` API on `Bambora::Client` from `profile` to `profiles`. This makes it more RESTful, and better aligns with the rest of the API.

**What To Test**

+ [x] Can create a profile from `bin/console`
+ [x] Can delete a profile from `bin/console`