### PR TITLE
Bump `excon` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     bambora-client (0.1.0)
-      excon (~> 0.67.0)
+      excon (~> 0.68.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    excon (0.67.0)
+    excon (0.68.0)
     hashdiff (1.0.0)
     jaro_winkler (1.5.3)
     method_source (0.9.2)

--- a/bambora-client.gemspec
+++ b/bambora-client.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'excon', '~> 0.67.0'
+  spec.add_dependency 'excon', '~> 0.68.0'
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'pry', '~> 0.12.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
**Description**

This PR bumps up the `excon` gem from `0.67.0` to `0.68.0`. There was a test failure in the previous version, according to their [builds](https://travis-ci.org/excon/excon/builds/603014207).

**What To Test**

+ [x] CI passes.