### PR TITLE
Streamline `Bambora::V1::ProfileResource` initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To use the profiles API, you must create an instance of the `Bambora::V1::Profil
 
 ```ruby
 client = Bambora::JSONClient.new(...)
-profiles = Bambora::V1::ProfileResource.new(client: client, sub_path: '/v1/profiles')
+profiles = Bambora::V1::ProfileResource.new(client: client)
 ```
 
 Once the resource instance has been instantiated, actions can be made against the API.

--- a/lib/bambora/v1/profile_resource.rb
+++ b/lib/bambora/v1/profile_resource.rb
@@ -3,6 +3,16 @@
 module Bambora
   module V1
     class ProfileResource
+      # Instantiate an interface to make requests against Bambora's Profiles API.
+      #
+      # @example
+      #
+      #   client = Bambora::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   profiles = Bambora::V1::ProfileResource(client: client)
+      #
+      #   # Start making requests ...
+      #
+      # @param client [Bambora::Client] An instance of Bambora::JSONClient, used to make network requests.
       def initialize(client:)
         @client = client
         @sub_path = '/v1/profiles'

--- a/lib/bambora/v1/profile_resource.rb
+++ b/lib/bambora/v1/profile_resource.rb
@@ -8,6 +8,35 @@ module Bambora
         @sub_path = '/v1/profiles'
       end
 
+      # Create a Bambora payment profile.
+      #
+      # @example
+      #
+      #   client = Bambora::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   profiles = Bambora::V1::ProfileResource(client: client)
+      #   data = {
+      #    language: 'en',
+      #     card: {
+      #       name: 'Hup Podling',
+      #       number: '4030000010001234',
+      #       expiry_month: '12',
+      #       expiry_year: '23',
+      #       cvd: '123',
+      #     },
+      #   }
+      #
+      #   profiles.create(data)
+      #   # => {
+      #   #      :code => 1,
+      #   #      :message => "Operation Successful",
+      #   #      :customer_code => "02355E2e58Bf488EAB4EaFAD7083dB6A",
+      #   #    }
+      #
+      # @param card_data [Hash] All information relevant to making a payment.
+      #
+      # @see https://dev.na.bambora.com/docs/guides/payment_profiles
+      #
+      # @return [Hash] Indicating success or failure of the operation.
       def create(card_data)
         @client.request(method: :post, path: @sub_path, body: card_data)
       end
@@ -18,7 +47,7 @@ module Bambora
       #
       #   client = Bambora::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
       #   profiles = Bambora::V1::ProfileResource(client: client)
-      #   customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A'
+      #   customer_code = '02355E2e58Bf488EAB4EaFAD7083dB6A'
       #
       #   profiles.delete(customer_code: customer_code)
       #   # => {

--- a/lib/bambora/v1/profile_resource.rb
+++ b/lib/bambora/v1/profile_resource.rb
@@ -12,6 +12,24 @@ module Bambora
         @client.request(method: :post, path: @sub_path, body: card_data)
       end
 
+      # Delete a Bambora payment profile given a customer code.
+      #
+      # @example
+      #
+      #   client = Bambora::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   profiles = Bambora::V1::ProfileResource(client: client)
+      #   customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A'
+      #
+      #   profiles.delete(customer_code: customer_code)
+      #   # => {
+      #   #      :code => 1,
+      #   #      :message => "Operation Successful",
+      #   #      :customer_code => "02355E2e58Bf488EAB4EaFAD7083dB6A",
+      #   #    }
+      #
+      # @param customer_code [String] A unique identifier for the associated payment profile.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
       def delete(customer_code:)
         @client.request(method: :delete, path: "#{@sub_path}/#{customer_code}")
       end

--- a/lib/bambora/v1/profile_resource.rb
+++ b/lib/bambora/v1/profile_resource.rb
@@ -3,9 +3,9 @@
 module Bambora
   module V1
     class ProfileResource
-      def initialize(client:, sub_path:)
+      def initialize(client:)
         @client = client
-        @sub_path = sub_path
+        @sub_path = '/v1/profiles'
       end
 
       def create(card_data)

--- a/spec/bambora/v1/profile_resource_spec.rb
+++ b/spec/bambora/v1/profile_resource_spec.rb
@@ -38,7 +38,7 @@ module Bambora
         )
       end
 
-      subject { Bambora::V1::ProfileResource.new(client: client, sub_path: '/v1/profiles') }
+      subject { Bambora::V1::ProfileResource.new(client: client) }
 
       describe '#create' do
         let(:data) do


### PR DESCRIPTION
**Description**

This PR updates the instantiation of a `Bambora::V1::ProfileResource` instance to not require (or allow) initialization of a `sub_path` parameter. This value is known already beforehand, and has therefore been made a class-level implementation detail.

**What To Test**

+ [x] CI Passes
+ [x] `rdoc` documentation is readable