### PR TITLE
Renaming make_payment to create & adding alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ Once the resource instance has been instantiated, actions can be made against th
 This is a lower level method that can be used to make a payment using any method. Below are some more specific and
 high level convenience methods.
 
+`create` is aliased as `make_payment` if you prefer syntax that reads more like a sentence.
+
 ```ruby
-payments.make_payment(
+payments.create(
   {
     amount: 50,
     payment_method: 'card',
@@ -172,8 +174,11 @@ payments.make_payment(
 
 ##### Make A Payment With A Payment Profile
 
+`create_with_payment_profile` is aliased as `make_payment_with_payment_profile` if you prefer syntax that reads more
+like a sentence.
+
 ```ruby
-payments.make_payment_with_payment_profile(customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A', amount: 50)
+payments.create_with_payment_profile(customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A', amount: 50)
 # => {
 #      :id => "10000000",
 #      :authorizing_merchant_id => 300000000,

--- a/lib/bambora/v1/payment_resource.rb
+++ b/lib/bambora/v1/payment_resource.rb
@@ -46,7 +46,6 @@ module Bambora
         @client.request(method: :post, path: @sub_path, body: payment_data)
       end
 
-      # An alias of +create+.
       alias make_payment create
 
       # Make a payment with a credit card. Aliased as +make_payment_with_payment_profile+.
@@ -60,7 +59,12 @@ module Bambora
       #     customer_code: '2355E2e58Bf488EAB4EaFAD7083dB6A', amount: 50, complete: false
       #   )
       #
-      # @param payment_data [Hash] All information relevant to making a payment.
+      # @param customer_code [String] Bambora's payment profile ID.
+      # @param amount [Float] A decimal value in dollars. Uses up to two decimal places. Max value is account specific.
+      #   Default max value is 1000.
+      # @param card_id [Integer] Default +1+. Which credit card to use. Starts at 1 for the first card. You must
+      #   configure how many cards can be stored by visiting the profile options in the back office.
+      # @param complete [Boolean] Default +false+. Set to false for Pre-Authorize, and true to complete a payment.
       #
       # @return [Hash] Indicating success or failure of the operation.
       def create_with_payment_profile(customer_code:, amount:, card_id: 1, complete: false)
@@ -75,7 +79,6 @@ module Bambora
         )
       end
 
-      # An alias of =create_with_payment_profile+.
       alias make_payment_with_payment_profile create_with_payment_profile
     end
   end

--- a/lib/bambora/v1/payment_resource.rb
+++ b/lib/bambora/v1/payment_resource.rb
@@ -14,12 +14,57 @@ module Bambora
         @sub_path = '/v1/payments'
       end
 
-      def make_payment(payment_data)
+      # Make a payment with a credit card. Also aliased as +make_payment+.
+      #
+      #
+      # @example
+      #
+      #   client = Bambora::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   payments = Bambora::V1::PaymentResource(client: client)
+      #   payments.create(
+      #     {
+      #       amount: 50,
+      #       payment_method: 'card',
+      #       card: {
+      #         name: 'Hup Podling',
+      #         number: '4504481742333',
+      #         expiry_month: '12',
+      #         expiry_year: '20',
+      #         cvd: '123',
+      #       },
+      #     },
+      #   )
+      #
+      # @param payment_data [Hash] All information relevant to making a payment.
+      #
+      # @see https://dev.na.bambora.com/docs/references/payment_APIs/
+      #
+      # @see https://dev.na.bambora.com/docs/references/payment_SDKs/take_payments/?shell#
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      def create(payment_data)
         @client.request(method: :post, path: @sub_path, body: payment_data)
       end
 
-      def make_payment_with_payment_profile(customer_code:, amount:, card_id: 1, complete: false)
-        make_payment(
+      # An alias of +create+.
+      alias make_payment create
+
+      # Make a payment with a credit card. Aliased as +make_payment_with_payment_profile+.
+      #
+      #
+      # @example
+      #
+      #   client = Bambora::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   payments = Bambora::V1::PaymentResource(client: client)
+      #   payments.create_with_payment_profile(
+      #     customer_code: '2355E2e58Bf488EAB4EaFAD7083dB6A', amount: 50, complete: false
+      #   )
+      #
+      # @param payment_data [Hash] All information relevant to making a payment.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      def create_with_payment_profile(customer_code:, amount:, card_id: 1, complete: false)
+        create(
           amount: amount,
           payment_method: 'payment_profile',
           payment_profile: {
@@ -29,6 +74,9 @@ module Bambora
           },
         )
       end
+
+      # An alias of =create_with_payment_profile+.
+      alias make_payment_with_payment_profile create_with_payment_profile
     end
   end
 end

--- a/spec/bambora/v1/payment_resource_spec.rb
+++ b/spec/bambora/v1/payment_resource_spec.rb
@@ -68,7 +68,7 @@ module Bambora
 
       subject { described_class.new(client: client) }
 
-      describe '#make_payment' do
+      describe '#create' do
         before(:each) do
           stub_request(:post, "#{base_url}/v1/payments").with(
             body: data.to_json.to_s,
@@ -91,7 +91,7 @@ module Bambora
         end
 
         it "POST's to the Bambora API" do
-          subject.make_payment(data)
+          subject.create(data)
 
           expect(
             a_request(:post, "#{base_url}/v1/payments").with(
@@ -102,7 +102,15 @@ module Bambora
         end
       end
 
-      describe '#make_payment_with_payment_profile' do
+      describe '#make_payment' do
+        subject { Bambora::V1::PaymentResource.new(client: client) }
+
+        it 'is an alias of #create_with_payment_profile' do
+          expect(subject.method(:make_payment)).to eq(subject.method(:create))
+        end
+      end
+
+      describe '#create_with_payment_profile' do
         before(:each) do
           stub_request(:post, "#{base_url}/v1/payments").with(
             body: data.to_json.to_s,
@@ -124,7 +132,7 @@ module Bambora
         end
 
         it "POST's to the Bambora API" do
-          subject.make_payment_with_payment_profile(customer_code: customer_code, amount: 50)
+          subject.create_with_payment_profile(customer_code: customer_code, amount: 50)
 
           expect(
             a_request(:post, "#{base_url}/v1/payments").with(
@@ -150,7 +158,7 @@ module Bambora
           end
 
           it 'sends the passed in values' do
-            subject.make_payment_with_payment_profile(
+            subject.create_with_payment_profile(
               customer_code: customer_code,
               amount: 50,
               card_id: card_id,
@@ -164,6 +172,14 @@ module Bambora
               ),
             ).to have_been_made.once
           end
+        end
+      end
+
+      describe '#make_payment_with_payment_profile' do
+        subject { Bambora::V1::PaymentResource.new(client: client) }
+
+        it 'is an alias of #create_with_payment_profile' do
+          expect(subject.method(:make_payment_with_payment_profile)).to eq(subject.method(:create_with_payment_profile))
         end
       end
     end


### PR DESCRIPTION
I renamed `make_payment` to `create` as it is more technically
correct when describing a rest API. However, `make_payment` does sound
more correct in an English sentence. I have added `make_payment` as an
alias of `create`.

I've made the same changes for `make_payment_with_payment_profile`.`