### PR TITLE
Allowing for older versions of Faraday

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     bambora-client (0.1.0)
       excon (~> 0.68.0)
-      faraday (~> 0.17)
+      faraday (>= 0.9, <= 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/bambora-client.gemspec
+++ b/bambora-client.gemspec
@@ -38,7 +38,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'excon', '~> 0.68.0'
-  spec.add_dependency 'faraday', '~> 0.17'
+  spec.add_dependency 'faraday', '>= 0.9', '<= 1.0'
+
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'pry', '~> 0.12.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.7.0'


### PR DESCRIPTION
hm-proj requires an older version of Faraday. Allowing for version 0.9.0 as we don't have any features here that require a higher version.