### PR TITLE
Checking only content type. Excluding charset

### DIFF
--- a/lib/bambora/factories/response_adapter_factory.rb
+++ b/lib/bambora/factories/response_adapter_factory.rb
@@ -6,7 +6,7 @@ module Bambora
   class ResponseAdapterFactory
     class << self
       def for(response)
-        content_type = response.headers['Content-Type']
+        content_type = response.headers['Content-Type'].split(';').first
         case content_type
           when 'application/json' then Bambora::JSONResponse.new(response)
           when 'text/html' then Bambora::QueryStringResponse.new(response)

--- a/spec/bambora/factories/response_adapter_factory_spec.rb
+++ b/spec/bambora/factories/response_adapter_factory_spec.rb
@@ -10,7 +10,7 @@ module Bambora
       subject { described_class.for(response) }
 
       context 'with a JSON request' do
-        let(:content_type) { 'application/json' }
+        let(:content_type) { 'application/json; charset=utf-8' }
         it { is_expected.to be_a JSONResponse }
       end
 


### PR DESCRIPTION
The JSON endpoints return the following content type: `application/json;
charset=utf-8`. We only care about the first part and not the charset.

THis raised an error when I tested the gem in staging.