### PR TITLE
Adding Batch Payments Resource

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       excon (< 1.0)
       faraday (< 1.0)
       gyoku (~> 1.0)
+      multiparty
 
 GEM
   remote: https://rubygems.org/
@@ -12,21 +13,26 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (11.0.1)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    excon (0.69.1)
-    faraday (0.17.0)
+    excon (0.70.0)
+    faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashdiff (1.0.0)
     jaro_winkler (1.5.3)
     method_source (0.9.2)
+    mime-types (3.3)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     multipart-post (2.1.1)
+    multiparty (0.2.0)
+      mime-types
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
@@ -84,4 +90,4 @@ DEPENDENCIES
   webmock (~> 3.7.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/bambora-client.gemspec
+++ b/bambora-client.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'excon', '< 1.0'
   spec.add_dependency 'faraday', '< 1.0'
   spec.add_dependency 'gyoku', '~> 1.0'
+  spec.add_dependency 'multiparty'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'pry', '~> 0.12.0'

--- a/lib/bambora/adapters/multipart_mixed_request.rb
+++ b/lib/bambora/adapters/multipart_mixed_request.rb
@@ -5,8 +5,6 @@ module Bambora
     ##
     # Creates headers and a body for a multipart/mixed request with a file and a JSON body.
     class MultipartMixedRequest
-      extend Forwardable
-
       attr_reader :multiparty
 
       def initialize(options = {})

--- a/lib/bambora/adapters/multipart_mixed_request.rb
+++ b/lib/bambora/adapters/multipart_mixed_request.rb
@@ -17,7 +17,9 @@ module Bambora
         multiparty.header.sub(/^Content-Type: /, '').strip
       end
 
-      def_delegator :multiparty, :body, :body
+      def body
+       "#{multiparty.body}\r\n"
+      end
     end
   end
 end

--- a/lib/bambora/adapters/multipart_mixed_request.rb
+++ b/lib/bambora/adapters/multipart_mixed_request.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Bambora
+  module Adapters
+    ##
+    # Creates headers and a body for a multipart/mixed request with a file and a JSON body.
+    class MultipartMixedRequest
+      extend Forwardable
+
+      attr_reader :multiparty
+
+      def initialize(options = {})
+        @multiparty = Multiparty.new { |party| party.parts = options[:multipart_args] }
+      end
+
+      def content_type
+        multiparty.header.sub(/^Content-Type: /, '').strip
+      end
+
+      def_delegator :multiparty, :body, :body
+    end
+  end
+end

--- a/lib/bambora/bank/payment_profile_resource.rb
+++ b/lib/bambora/bank/payment_profile_resource.rb
@@ -3,7 +3,7 @@
 module Bambora
   module Bank
     ##
-    # For making requests to the /scripts/payment_profiles.asp endpoint
+    # For making requests to the /scripts/payment_profile.asp endpoint
     #
     # @see https://help.na.bambora.com/hc/en-us/articles/115010346067-Secure-Payment-Profiles-Batch-Payments
     class PaymentProfileResource

--- a/lib/bambora/builders/batch_payment_csv.rb
+++ b/lib/bambora/builders/batch_payment_csv.rb
@@ -18,7 +18,7 @@ module Bambora
         #     account_number: 1223456789,
         #     amount: 10000
         #     reference_nubmer: 1234,
-        #     reccipient_name: 'Hup Podling',
+        #     recipient_name: 'Hup Podling',
         #     customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A',
         #     dynamic_description: 'The Skeksis',
         #   }])

--- a/lib/bambora/builders/batch_payment_csv.rb
+++ b/lib/bambora/builders/batch_payment_csv.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Bambora
+  module Builders
+    class BatchPaymentCSV
+      class << self
+        ##
+        # Return a CSV with one transaction per row.
+        #
+        # @see https://dev.na.bambora.com/docs/references/batch_payment/
+        #
+        # @example
+        #   Bambora::Builders::BatchPaymentCSV.build([{
+        #     super_type: 'E',
+        #     transaction_type: 'D',
+        #     institution_number: 12345,
+        #     transit_number: 123,
+        #     account_number: 1223456789,
+        #     amount: 10000
+        #     reference_nubmer: 1234,
+        #     reccipient_name: 'Hup Podling',
+        #     customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A',
+        #     dynamic_description: 'The Skeksis',
+        #   }])
+        #
+        #   # => "E,D,12345,123,123456789,10000,1234,Hup Podling,02355E2e58Bf488EAB4EaFAD7083dB6A,The Skeksis\n"
+        #
+        # @param transactions [Array] an array of transaciton hashes.
+        #
+        # @return [String], a CSV as a string
+        def build(transactions)
+          CSV.generate do |csv|
+            transactions.each do |transaction|
+              csv << transaction.values
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -9,7 +9,7 @@ require 'json'
 # Gems
 require 'faraday' # HTTP Wraper
 require 'gyoku' # XML Builder
-require 'multiparty' # Multipart/mixed requestss
+require 'multiparty' # Multipart/mixed requests
 
 require 'bambora/client/version'
 

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -8,12 +8,14 @@ require 'json'
 # Gems
 require 'faraday' # HTTP Wraper
 require 'gyoku' # XML Builder
+require 'multiparty' # Multipart/mixed requestss
 
 require 'bambora/client/version'
 
 # Adapters
 require 'bambora/adapters/response'
 require 'bambora/adapters/json_response'
+require 'bambora/adapters/multipart_mixed_request'
 require 'bambora/adapters/query_string_response'
 require 'bambora/bank/adapters/payment_profile_response'
 

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -3,6 +3,7 @@
 # Standard Libraries
 require 'base64'
 require 'cgi'
+require 'csv'
 require 'json'
 
 # Gems
@@ -23,6 +24,7 @@ require 'bambora/bank/adapters/payment_profile_response'
 require 'bambora/builders/headers'
 require 'bambora/builders/xml_request_body'
 require 'bambora/builders/www_form_parameters'
+require 'bambora/builders/batch_payment_csv'
 require 'bambora/bank/builders/payment_profile_params'
 
 # Factories

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -174,19 +174,9 @@ module Bambora
     def batch_payment_file_upload_client
       Bambora::Rest::BatchPaymentFileUploadClient.new(
         base_url: base_url,
-        connection: connection,
         merchant_id: merchant_id,
         sub_merchant_id: sub_merchant_id,
       )
-    end
-
-    # TODO: Refactor other Clients to receive a connection as well.
-    def connection
-      @connection ||= Faraday.new(url: base_url) do |faraday|
-        faraday.request :multipart
-        faraday.request :url_encoded
-        faraday.adapter :excon
-      end
     end
   end
 end

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -30,6 +30,7 @@ require 'bambora/factories/response_adapter_factory'
 
 # Clients
 require 'bambora/rest/client'
+require 'bambora/rest/batch_payment_file_upload_client'
 require 'bambora/rest/json_client'
 require 'bambora/rest/www_form_client'
 require 'bambora/rest/xml_client'

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -146,7 +146,12 @@ module Bambora
 
     def batch_payment_reports; end
 
-    def batch_payments; end
+    def batch_payments(api_key:)
+      @batch_payments ||= Bambora::V1::BatchPaymentResource.new(
+        client: batch_payment_file_upload_client,
+        api_key: api_key
+      )
+    end
 
     private
 
@@ -164,6 +169,24 @@ module Bambora
         merchant_id: merchant_id,
         sub_merchant_id: sub_merchant_id,
       )
+    end
+
+    def batch_payment_file_upload_client
+      Bambora::Rest::BatchPaymentFileUploadClient.new(
+        base_url: base_url,
+        connection: connection,
+        merchant_id: merchant_id,
+        sub_merchant_id: sub_merchant_id,
+      )
+    end
+
+    # TODO: Refactor other Clients to receive a connection as well.
+    def connection
+      @connection ||= Faraday.new(url: base_url) do |faraday|
+        faraday.request :multipart
+        faraday.request :url_encoded
+        faraday.adapter :excon
+      end
     end
   end
 end

--- a/lib/bambora/client.rb
+++ b/lib/bambora/client.rb
@@ -172,7 +172,7 @@ module Bambora
     end
 
     def batch_payment_file_upload_client
-      Bambora::Rest::BatchPaymentFileUploadClient.new(
+      @batch_payment_file_upload_client ||= Bambora::Rest::BatchPaymentFileUploadClient.new(
         base_url: base_url,
         merchant_id: merchant_id,
         sub_merchant_id: sub_merchant_id,

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -4,7 +4,7 @@ module Bambora
   module Rest
     class BatchPaymentFileUploadClient < Bambora::Rest::Client
       CONTENT_DISPOSITION = 'form-data'
-      CONTENT_TYPES ={
+      CONTENT_TYPES = {
         text_plain: 'text/plain',
         application_json: 'application/json',
       }.freeze

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -46,6 +46,7 @@ module Bambora
           content_type: @payload.content_type,
           api_key: api_key,
           merchant_id: merchant_id,
+          sub_merchant_id: sub_merchant_id,
         ).build
       end
     end

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -22,7 +22,7 @@ module Bambora
 
       private
 
-      def init_payload(file_contents, params)
+      def init_payload(file_contents, options)
         return @payload if @payload
 
         @payload = Bambora::Adapters::MultipartMixedRequest.new(
@@ -30,7 +30,7 @@ module Bambora
             criteria: {
               content_disposition: CONTENT_DISPOSITION,
               content_type: JSON_CONTENT_TYPE,
-              content: params.to_json,
+              content: options.to_json,
             },
             data: {
               filename: "merchant_#{sub_merchant_id}.txt",

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -4,9 +4,11 @@ module Bambora
   module Rest
     class BatchPaymentFileUploadClient < Bambora::Rest::Client
       CONTENT_DISPOSITION = 'form-data'
-      FILE_CONTENT_TYPE = 'text/plain'
+      CONTENT_TYPES ={
+        text_plain: 'text/plain',
+        application_json: 'application/json',
+      }.freeze
       FILE_TYPE_HEADER = { 'FileType' => 'STD' }
-      JSON_CONTENT_TYPE = 'application/json'
 
       # @param args[:file_contents] [String] CSV file contents
       # @param args[:options] [Hash] Request Parameters as documented by Bambora.
@@ -31,12 +33,12 @@ module Bambora
           multipart_args: {
             criteria: {
               content_disposition: CONTENT_DISPOSITION,
-              content_type: JSON_CONTENT_TYPE,
+              content_type: CONTENT_TYPES[:application_json],
               content: options.to_json,
             },
             data: {
               filename: "merchant_#{sub_merchant_id}.txt",
-              content_type: FILE_CONTENT_TYPE,
+              content_type: CONTENT_TYPES[:text_plain],
               content: file_contents,
             },
           },

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -8,7 +8,7 @@ module Bambora
         text_plain: 'text/plain',
         application_json: 'application/json',
       }.freeze
-      FILE_TYPE_HEADER = { 'FileType' => 'STD' }
+      FILE_TYPE_HEADER = { 'FileType' => 'STD' }.freeze
 
       # @param args[:file_contents] [String] CSV file contents
       # @param args[:options] [Hash] Request Parameters as documented by Bambora.

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -3,8 +3,9 @@
 module Bambora
   module Rest
     class BatchPaymentFileUploadClient < Bambora::Rest::Client
-      CONTENT_DISPOSITION = "form-data; name='criteria'"
+      CONTENT_DISPOSITION = 'form-data'
       FILE_CONTENT_TYPE = 'text/plain'
+      FILE_TYPE_HEADER = { 'FileType' => 'STD' }
       JSON_CONTENT_TYPE = 'application/json'
 
       # @param args[:file_contents] [String] CSV file contents
@@ -15,8 +16,9 @@ module Bambora
         parse_response_body(
           super(
             path: args[:path],
-            body: @payload.body,
-            headers: build_headers(api_key: args[:api_key])),
+            body: "#{@payload.body}\r\n",
+            headers: build_headers(api_key: args[:api_key]).merge(FILE_TYPE_HEADER),
+          ),
         ).to_h
       end
 
@@ -46,7 +48,6 @@ module Bambora
           content_type: @payload.content_type,
           api_key: api_key,
           merchant_id: merchant_id,
-          sub_merchant_id: sub_merchant_id,
         ).build
       end
     end

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Bambora
+  module Rest
+    class BatchPaymentFileUploadClient < Bambora::Rest::Client
+      CONTENT_DISPOSITION = "form-data; name='criteria'"
+      FILE_CONTENT_TYPE = 'text/plain'
+      JSON_CONTENT_TYPE = 'application/json'
+
+      # @param args[:file_contents] [String] CSV file contents
+      # @param args[:options] [Hash] Request Parameters as documented by Bambora.
+      # @param args[:api_key] [String]
+      def post(args = {})
+        init_payload(args[:file_contents], args[:options])
+        parse_response_body(
+          super(
+            path: args[:path],
+            body: @payload.body,
+            headers: build_headers(api_key: args[:api_key])),
+        ).to_h
+      end
+
+      private
+
+      def init_payload(file_contents, params)
+        return @payload if @payload
+
+        @payload = Bambora::Adapters::MultipartMixedRequest.new(
+          multipart_args: {
+            criteria: {
+              content_disposition: CONTENT_DISPOSITION,
+              content_type: JSON_CONTENT_TYPE,
+              content: params.to_json,
+            },
+            data: {
+              filename: "merchant_#{sub_merchant_id}.txt",
+              content_type: FILE_CONTENT_TYPE,
+              content: file_contents,
+            },
+          },
+        )
+      end
+
+      def build_headers(api_key:)
+        Bambora::Builders::Headers.new(
+          content_type: @payload.content_type,
+          api_key: api_key,
+          merchant_id: merchant_id,
+        ).build
+      end
+    end
+  end
+end

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -17,7 +17,7 @@ module Bambora
           super(
             path: args[:path],
             body: @payload.body,
-            headers: build_headers(api_key: args[:api_key]).merge(FILE_TYPE_HEADER),
+            headers: build_headers(api_key: args[:api_key]),
           ),
         ).to_h
       end
@@ -44,11 +44,12 @@ module Bambora
       end
 
       def build_headers(api_key:)
-        Bambora::Builders::Headers.new(
+        headers = Bambora::Builders::Headers.new(
           content_type: @payload.content_type,
           api_key: api_key,
           merchant_id: merchant_id,
         ).build
+        headers.merge(FILE_TYPE_HEADER)
       end
     end
   end

--- a/lib/bambora/rest/batch_payment_file_upload_client.rb
+++ b/lib/bambora/rest/batch_payment_file_upload_client.rb
@@ -16,7 +16,7 @@ module Bambora
         parse_response_body(
           super(
             path: args[:path],
-            body: "#{@payload.body}\r\n",
+            body: @payload.body,
             headers: build_headers(api_key: args[:api_key]).merge(FILE_TYPE_HEADER),
           ),
         ).to_h

--- a/lib/bambora/rest/client.rb
+++ b/lib/bambora/rest/client.rb
@@ -40,6 +40,8 @@ module Bambora
 
       def connection
         @connection ||= Faraday.new(url: base_url) do |faraday|
+          faraday.request :multipart
+          faraday.request :url_encoded
           faraday.adapter :excon
         end
       end

--- a/lib/bambora/v1/batch_payment_resource.rb
+++ b/lib/bambora/v1/batch_payment_resource.rb
@@ -33,7 +33,7 @@ module Bambora
       #
       # @param transactions [Array] of hashes with payment data.
       # @param opts[:process_now] [Integer] optional. Defaults to 1.
-      # @param opts[:process_date] [String] optional. Must also set process_now to 0.
+      # @param opts[:process_date] [String] optional. Must exclude +process_now+ or pass +{ process_now: 0 }+
       #
       # @see https://dev.na.bambora.com/docs/references/batch_payment/
       # @see https://dev.na.bambora.com/docs/guides/batch_payment/

--- a/lib/bambora/v1/batch_payment_resource.rb
+++ b/lib/bambora/v1/batch_payment_resource.rb
@@ -13,7 +13,9 @@ module Bambora
       end
 
       ##
-      # Post batch payment data.
+      # Post batch payment data. Transaction objects must have keys that match the order of the columns defined in the
+      # Bambora documentation.https://dev.na.bambora.com/docs/references/batch_payment/#format-of-data-in-file
+      # The values of each object are used to create one row of a CSV.
       #
       # @example
       #   batch_payment_resource.create(

--- a/lib/bambora/v1/batch_payment_resource.rb
+++ b/lib/bambora/v1/batch_payment_resource.rb
@@ -2,10 +2,7 @@
 
 module Bambora
   module V1
-    # Summary: Bank Electronic Funds Transfer (CAD) and Automatic Clearing House (USD)
-    # Docs: https://dev.na.bambora.com/docs/guides/batch_payment/
-    #       https://dev.na.bambora.com/docs/references/batch_payment/
-    # Endpoint: https://api.na.bambora.com/v1/batchpayments
+    # Bank Electronic Funds Transfer (CAD) and Automatic Clearing House (USD)
     class BatchPaymentResource
       attr_reader :client, :api_key, :sub_path
 
@@ -16,7 +13,10 @@ module Bambora
       end
 
       ##
+      # Post batch payment data.
+      #
       # @see https://dev.na.bambora.com/docs/references/batch_payment/
+      # @see https://dev.na.bambora.com/docs/guides/batch_payment/
       #
       # @example
       #   batch_payment_resource.create(
@@ -33,19 +33,16 @@ module Bambora
       #       dynamic_description: 'The Skeksis',
       #     }],
       #   )
-      def create(transactions, opts = { process_now: true })
+      #
+      # @param transactions [Array] of hashes with payment data.
+      # @param opts[:process_now] [Integer]
+      def create(transactions, opts = { process_now: 1 })
         client.post(
           path: sub_path,
-          file_contents: csv_string(transactions),
+          file_contents: Bambora::Builders::BatchPaymentCSV.build(transactions),
           options: opts,
           api_key: api_key,
         )
-      end
-
-      private
-
-      def csv_string(transactions)
-        Bambora::Builders::BatchPaymentCSV.build(transactions)
       end
     end
   end

--- a/lib/bambora/v1/batch_payment_resource.rb
+++ b/lib/bambora/v1/batch_payment_resource.rb
@@ -15,9 +15,6 @@ module Bambora
       ##
       # Post batch payment data.
       #
-      # @see https://dev.na.bambora.com/docs/references/batch_payment/
-      # @see https://dev.na.bambora.com/docs/guides/batch_payment/
-      #
       # @example
       #   batch_payment_resource.create(
       #     [{
@@ -35,12 +32,16 @@ module Bambora
       #   )
       #
       # @param transactions [Array] of hashes with payment data.
-      # @param opts[:process_now] [Integer]
+      # @param opts[:process_now] [Integer] optional. Defaults to 1.
+      # @param opts[:process_date] [String] optional. Must also set process_now to 0.
+      #
+      # @see https://dev.na.bambora.com/docs/references/batch_payment/
+      # @see https://dev.na.bambora.com/docs/guides/batch_payment/
       def create(transactions, opts = { process_now: 1 })
         client.post(
           path: sub_path,
           file_contents: Bambora::Builders::BatchPaymentCSV.build(transactions),
-          options: opts,
+          options: opts.merge(sub_merchant_id: client.sub_merchant_id),
           api_key: api_key,
         )
       end

--- a/lib/bambora/v1/batch_payment_resource.rb
+++ b/lib/bambora/v1/batch_payment_resource.rb
@@ -2,14 +2,50 @@
 
 module Bambora
   module V1
+    # Summary: Bank Electronic Funds Transfer (CAD) and Automatic Clearing House (USD)
+    # Docs: https://dev.na.bambora.com/docs/guides/batch_payment/
+    #       https://dev.na.bambora.com/docs/references/batch_payment/
+    # Endpoint: https://api.na.bambora.com/v1/batchpayments
     class BatchPaymentResource
-      # Summary: Bank Electronic Funds Transfer (CAD) and Automatic Clearing House (USD)
-      # Docs: https://dev.na.bambora.com/docs/guides/batch_payment/
-      #       https://dev.na.bambora.com/docs/references/batch_payment/
-      # Endpoint: https://api.na.bambora.com/v1/batchpayments
-      def initialize(client:, sub_path:)
+      attr_reader :client, :api_key, :sub_path
+
+      def initialize(client:, api_key:)
         @client = client
-        @sub_path = sub_path
+        @api_key = api_key
+        @sub_path = '/v1/batchpayments'
+      end
+
+      ##
+      # @see https://dev.na.bambora.com/docs/references/batch_payment/
+      #
+      # @example
+      #   batch_payment_resource.create(
+      #     [{
+      #       super_type: 'E',
+      #       transaction_type: 'D',
+      #       institution_number: 12345,
+      #       transit_number: 123,
+      #       account_number: 1223456789,
+      #       amount: 10000,
+      #       reference_nubmer: 1234,
+      #       reccipient_name: 'Hup Podling',
+      #       customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A',
+      #       dynamic_description: 'The Skeksis',
+      #     }],
+      #   )
+      def create(transactions, opts = { process_now: true })
+        client.post(
+          path: sub_path,
+          file_contents: csv_string(transactions),
+          options: opts,
+          api_key: api_key,
+        )
+      end
+
+      private
+
+      def csv_string(transactions)
+        Bambora::Builders::BatchPaymentCSV.build(transactions)
       end
     end
   end

--- a/spec/bambora/adapters/multipart_mixed_request_spec.rb
+++ b/spec/bambora/adapters/multipart_mixed_request_spec.rb
@@ -32,7 +32,9 @@ module Bambora
 
       describe '#content_type' do
         it 'returns the correct content type' do
-          expect(multipart_request.content_type).to include %r{^multipart/form-data; boundary=multiparty-boundary-r}
+          expect(multipart_request.content_type.sub(/-\d+/, '')).to(
+            eq('multipart/form-data; boundary=multiparty-boundary'),
+          )
         end
       end
     end

--- a/spec/bambora/adapters/multipart_mixed_request_spec.rb
+++ b/spec/bambora/adapters/multipart_mixed_request_spec.rb
@@ -37,6 +37,12 @@ module Bambora
           )
         end
       end
+
+      describe '#body' do
+        it 'returns the body with a carrage return at the end' do
+          expect(multipart_request.body.chars.last(2)).to eq ["\r", "\n"]
+        end
+      end
     end
   end
 end

--- a/spec/bambora/adapters/multipart_mixed_request_spec.rb
+++ b/spec/bambora/adapters/multipart_mixed_request_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Bambora
+  module Adapters
+    describe MultipartMixedRequest do
+      subject(:multipart_request) { described_class.new(multipart_args: multipart_args) }
+
+      let(:csv_content) do
+        <<~CSV
+          E,C,001,99001,09400313371,10000,1000070001,ACME Corp
+          E,C,002,99002,09400313372,20000,1000070002,John Doe
+          E,C,003,99003,09400313373,30000,1000070003,Jane Doe
+        CSV
+      end
+
+      let(:multipart_args) do
+        {
+          criteria: {
+            content_disposition: 'Content-Disposition: form-data; name="criteria',
+            content_type: 'application/json',
+            content: { process_now: 1 }.to_json,
+          },
+          data: {
+            filename: 'merchant_1.txt',
+            content_type: 'text/plain',
+            content: csv_content,
+          },
+        }
+      end
+
+      describe '#content_type' do
+        it 'returns the correct content type' do
+          expect(multipart_request.content_type).to include %r{^multipart/form-data; boundary=multiparty-boundary-r}
+        end
+      end
+    end
+  end
+end

--- a/spec/bambora/builders/batch_payment_csv_spec.rb
+++ b/spec/bambora/builders/batch_payment_csv_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Bambora
+  module Builders
+    describe BatchPaymentCSV do
+      describe '#build' do
+        let(:transactions) do
+          [
+            {
+              super_type: 'E',
+              transaction_type: 'D',
+              institution_number: 12_345,
+              transit_number: 123,
+              account_number: 123_456_789,
+              amount: 10_000,
+              reference_nubmer: 1234,
+              reccipient_name: 'Hup Podling',
+              customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A',
+              dynamic_description: 'The Skeksis',
+            },
+          ]
+        end
+
+        let(:csv_string) do
+          "E,D,12345,123,123456789,10000,1234,Hup Podling,02355E2e58Bf488EAB4EaFAD7083dB6A,The Skeksis\n"
+        end
+
+        subject { described_class.build(transactions) }
+
+        it { is_expected.to eq(csv_string) }
+      end
+    end
+  end
+end

--- a/spec/bambora/rest/batch_payment_file_upload_client_spec.rb
+++ b/spec/bambora/rest/batch_payment_file_upload_client_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Bambora
+  module Rest
+    describe BatchPaymentFileUploadClient do
+      subject(:client) do
+        described_class.new(base_url: base_url, merchant_id: merchant_id, sub_merchant_id: sub_merchant_id)
+      end
+
+      let(:merchant_id) { 1 }
+      let(:sub_merchant_id) { 2 }
+      let(:base_url) { 'https://sandbox-api.na.bambora.com' }
+      let(:api_key) { 'fakekey' }
+      let(:csv_content) do
+        <<~CSV
+          E,C,001,99001,09400313371,10000,1000070001,ACME Corp
+          E,C,002,99002,09400313372,20000,1000070002,John Doe
+          E,C,003,99003,09400313373,30000,1000070003,Jane Doe
+        CSV
+      end
+      let(:options) { { process_now: 1 } }
+      let(:response_headers) { { 'Content-Type' => 'application/json' } }
+      let(:response_body) do
+        {
+          code: 1,
+          message: 'File successfully received',
+          batch_id: '100',
+          process_date: Date.today.to_s,
+          process_time_zone: 'GMT-08:00',
+          batch_mode: 'live',
+        }
+      end
+
+      let(:request_body) do
+        <<~BODY
+					--multiparty-boundary-50428029
+					Content-Disposition: form-data; name='criteria'; name="criteria"
+					Content-Type: application/json
+
+					{"process_now":1}
+					--multiparty-boundary-50428029
+					Content-Disposition: form-data; name="data"; filename="merchant_2.txt"
+					Content-Type: text/plain
+					Content-Transfer-Encoding: binary
+
+					E,C,001,99001,09400313371,10000,1000070001,ACME Corp
+					E,C,002,99002,09400313372,20000,1000070002,John Doe
+					E,C,003,99003,09400313373,30000,1000070003,Jane Doe
+
+					--multiparty-boundary-50428029--
+        BODY
+      end
+
+      let(:multipart_mixed_request_class) do
+        class_double('Bambora::Adapters::MultipartMixedRequest').as_stubbed_const(transfer_nested_constants: true)
+      end
+
+      let(:multipart_double) do
+        instance_double(
+          'Bambora::Adapters::MultipartMixedRequest',
+          body: request_body,
+          content_type: 'multipart/form-data; boundary=multiparty-boundary-50428029',
+        )
+      end
+
+      let(:multipart_args) do
+        {
+          multipart_args: {
+            criteria: {
+              content_disposition: "form-data; name='criteria'",
+              content_type: 'application/json',
+              content: options.to_json,
+            },
+            data: {
+              filename: "merchant_#{sub_merchant_id}.txt",
+              content_type: 'text/plain',
+              content: csv_content,
+            },
+          },
+        }
+      end
+
+      describe '#create' do
+        context 'server responds with a 2xx status' do
+          before do
+            allow(multipart_mixed_request_class).to receive(:new).with(multipart_args).and_return(multipart_double)
+            # WebMock does not support verifying the body with a regex on a multi-part form request.
+            stub_request(:post, base_url).with(
+              headers: {
+                'Authorization' => 'Passcode MTpmYWtla2V5',
+              },
+            ).to_return(headers: response_headers, body: response_body.to_json.to_s)
+          end
+
+          it 'parses the response' do
+            resp = client.post(file_contents: csv_content, options: options, api_key: api_key)
+            expect(resp).to eq response_body
+          end
+
+          it 'sends the correct parameters to MultipartMixedRequest' do
+            client.post(file_contents: csv_content, options: options, api_key: api_key)
+            expect(multipart_mixed_request_class).to have_received(:new).with(multipart_args)
+          end
+        end
+
+        context 'server responds with a non 2xx status' do
+          let(:failed_status) { 500 }
+          let(:failed_response_body) { 'Mouldy mildew, mother of mouthmuck, dangle and strangle and death.' }
+
+          before do
+            stub_request(:post, base_url).with(
+              headers: {
+                'Authorization' => 'Passcode MTpmYWtla2V5',
+              },
+            ).to_return(headers: response_headers, body: failed_response_body, status: failed_status)
+          end
+
+          it 'parses the response' do
+            resp = client.post(file_contents: csv_content, options: options, api_key: api_key)
+            expect(resp).to eq(status: failed_status, body: failed_response_body)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bambora/rest/batch_payment_file_upload_client_spec.rb
+++ b/spec/bambora/rest/batch_payment_file_upload_client_spec.rb
@@ -35,21 +35,21 @@ module Bambora
 
       let(:request_body) do
         <<~BODY
-					--multiparty-boundary-50428029
-					Content-Disposition: form-data; name="criteria"
-					Content-Type: application/json
+          --multiparty-boundary-50428029
+          Content-Disposition: form-data; name="criteria"
+          Content-Type: application/json
 
-					{"process_now":1}
-					--multiparty-boundary-50428029
-					Content-Disposition: form-data; name="data"; filename="merchant_2.txt"
-					Content-Type: text/plain
-					Content-Transfer-Encoding: binary
+          {"process_now":1}
+          --multiparty-boundary-50428029
+          Content-Disposition: form-data; name="data"; filename="merchant_2.txt"
+          Content-Type: text/plain
+          Content-Transfer-Encoding: binary
 
-					E,C,001,99001,09400313371,10000,1000070001,ACME Corp
-					E,C,002,99002,09400313372,20000,1000070002,John Doe
-					E,C,003,99003,09400313373,30000,1000070003,Jane Doe
+          E,C,001,99001,09400313371,10000,1000070001,ACME Corp
+          E,C,002,99002,09400313372,20000,1000070002,John Doe
+          E,C,003,99003,09400313373,30000,1000070003,Jane Doe
 
-					--multiparty-boundary-50428029--
+          --multiparty-boundary-50428029--
         BODY
       end
 

--- a/spec/bambora/v1/batch_payment_resource_spec.rb
+++ b/spec/bambora/v1/batch_payment_resource_spec.rb
@@ -12,20 +12,7 @@ module Bambora
       let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5', 'Sub-Merchant-ID' => sub_merchant_id } }
 
       let(:transactions) do
-        [
-          {
-            super_type: 'E',
-            transaction_type: 'D',
-            institution_number: 12_345,
-            transit_number: 123,
-            account_number: 1_223_456_789,
-            amount: 10_000,
-            reference_nubmer: 1234,
-            reccipient_name: 'Hup Podling',
-            customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A',
-            dynamic_description: 'The Skeksis',
-          },
-        ]
+        [ { super_type: 'E', transaction_type: 'D', institution_number: 12_345, transit_number: 123, account_number: 1_223_456_789, amount: 10_000, reference_nubmer: 1234, reccipient_name: 'Hup Podling', customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A', dynamic_description: 'The Skeksis' } ]
       end
 
       let(:file_contents) do
@@ -46,7 +33,6 @@ module Bambora
       describe '#create' do
         before do
         end
-
 
         it 'sends post to the client' do
           expect(client).to receive(:post).with(


### PR DESCRIPTION
This PR adds the Batch Payments endpoint to this gem. It allows us to upload a CSV for batch processing.

This has been tested against a test account.

## What to test
- [x] Can submit test batch payments to the Bambora API and get the
expected response back.