### PR TITLE
Adding CRLF line endings to CSV

### DIFF
--- a/lib/bambora/builders/batch_payment_csv.rb
+++ b/lib/bambora/builders/batch_payment_csv.rb
@@ -29,7 +29,7 @@ module Bambora
         #
         # @return [String], a CSV as a string
         def build(transactions)
-          CSV.generate do |csv|
+          CSV.generate(row_sep: "\r\n") do |csv|
             transactions.each do |transaction|
               csv << transaction.values
             end

--- a/spec/bambora/builders/batch_payment_csv_spec.rb
+++ b/spec/bambora/builders/batch_payment_csv_spec.rb
@@ -24,12 +24,12 @@ module Bambora
         end
 
         let(:csv_string) do
-          "E,D,12345,123,123456789,10000,1234,Hup Podling,02355E2e58Bf488EAB4EaFAD7083dB6A,The Skeksis\n"
+          "E,D,12345,123,123456789,10000,1234,Hup Podling,02355E2e58Bf488EAB4EaFAD7083dB6A,The Skeksis\r\n"
         end
 
-        subject { described_class.build(transactions) }
-
-        it { is_expected.to eq(csv_string) }
+        it 'generates a CSV with CRLF line endings' do
+          expect(described_class.build(transactions)).to eq csv_string
+        end
       end
     end
   end

--- a/spec/bambora/v1/batch_payment_resource_spec.rb
+++ b/spec/bambora/v1/batch_payment_resource_spec.rb
@@ -29,7 +29,7 @@ module Bambora
       end
 
       let(:file_contents) do
-        "E,D,12345,123,1223456789,10000,1234,Hup Podling,02355E2e58Bf488EAB4EaFAD7083dB6A,The Skeksis\n"
+        "E,D,12345,123,1223456789,10000,1234,Hup Podling,02355E2e58Bf488EAB4EaFAD7083dB6A,The Skeksis\r\n"
       end
 
       let(:client) do


### PR DESCRIPTION
According to Bambora, their system runs on windows and needs CRLF line endings rather than CR.