### PR TITLE
Bugfix: Handle null record from Bambora Batch Bank Report queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2 (2020-04-14)
+
+- Fix nil record with Bank Batch Report returns
+
 ## 0.1.1 (2020-03-04)
 
 - Upgrade `rake` to `13.0.1`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bambora-client (0.1.0)
+    bambora-client (0.1.2)
       excon (< 1.0)
       faraday (< 1.0)
       gyoku (~> 1.0)
@@ -19,15 +19,15 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    excon (0.71.0)
-    faraday (0.17.1)
+    excon (0.73.0)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashdiff (1.0.0)
     jaro_winkler (1.5.3)
     method_source (0.9.2)
-    mime-types (3.3)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     multipart-post (2.1.1)

--- a/lib/bambora/bank/batch_report_resource.rb
+++ b/lib/bambora/bank/batch_report_resource.rb
@@ -61,9 +61,14 @@ module Bambora
       private
 
       def add_messages_to_response(response)
+        # bambora can return null or empty record results
+        records = response.dig(:response, :record)
+        return response if records.nil?
+
         response.dig(:response, :record).map! do |record|
           record.merge!(messages: record[:messageId].split(',').map { |id| MESSAGES[id] })
         end
+
         response
       end
 

--- a/lib/bambora/bank/batch_report_resource.rb
+++ b/lib/bambora/bank/batch_report_resource.rb
@@ -61,9 +61,8 @@ module Bambora
       private
 
       def add_messages_to_response(response)
-        # bambora can return null or empty record results
-        records = response.dig(:response, :record)
-        return response if records.nil?
+        # bambora can return null or empty record results, don't decorate with messages
+        return response if response.dig(:response, :record).nil?
 
         response.dig(:response, :record).map! do |record|
           record.merge!(messages: record[:messageId].split(',').map { |id| MESSAGES[id] })

--- a/lib/bambora/client/version.rb
+++ b/lib/bambora/client/version.rb
@@ -2,6 +2,6 @@
 
 module Bambora
   class Client
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end

--- a/spec/bambora/bank/batch_report_resource_spec.rb
+++ b/spec/bambora/bank/batch_report_resource_spec.rb
@@ -223,6 +223,38 @@ module Bambora
             expect(reports.show(request_data)).to eq expected_response
           end
         end
+
+        context 'with nil records' do
+          let(:response_body) do
+            {
+              response: {
+                version: '1.0',
+                code: 1,
+                message: 'Report generated',
+                records: {
+                  total: 0,
+                },
+              },
+            }
+          end
+
+          let(:expected_response) do
+            {
+              response: {
+                version: '1.0',
+                code: 1,
+                message: 'Report generated',
+                records: {
+                  total: 0,
+                },
+              },
+            }
+          end
+
+          it 'returns the expected response' do
+            expect(reports.show(request_data)).to eq expected_response
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
**Description**

For some Bambora Batch Bank Report queries, the `report` is null. Previously, we were attempting to call `map!` on a `nil` object. This avoids the call and returns the undecorated `response` back up the stack. 

The test included demonstrates the bug, and the fix makes it pass.

This is related to the HiMama ticket: https://himama.atlassian.net/browse/ENG-505
And the Sentry bug: https://sentry.io/organizations/himama-inc/issues/1520181007/