### PR TITLE
Ensure batch bank report response has a `:record` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.3 (2020-04-30)
 
-- Ensure Batch Batch Report returns empty array `:record` in response at the very least
+- Ensure Batch Report returns empty array `:record` in response at the very least
 
 ## 0.1.2 (2020-04-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3 (2020-04-30)
+
+- Ensure Batch Batch Report returns empty array `:record` in response at the very least
+
 ## 0.1.2 (2020-04-14)
 
 - Fix nil record with Bank Batch Report returns

--- a/lib/bambora/bank/batch_report_resource.rb
+++ b/lib/bambora/bank/batch_report_resource.rb
@@ -62,7 +62,7 @@ module Bambora
 
       def add_messages_to_response(response)
         # bambora can return null or empty record results, don't decorate with messages
-        return response if response.dig(:response, :record).nil?
+        response.dig(:response)[:record] = [] if response.dig(:response, :record).nil?
 
         response.dig(:response, :record).map! do |record|
           record.merge!(messages: record[:messageId].split(',').map { |id| MESSAGES[id] })

--- a/lib/bambora/bank/batch_report_resource.rb
+++ b/lib/bambora/bank/batch_report_resource.rb
@@ -53,17 +53,24 @@ module Bambora
       #
       #  @params profile_data [Hash] with values as noted in the example.
       def show(report_data)
-        add_messages_to_response(
-          client.post(path: sub_path, body: batch_report_body(report_data)),
-        )
+        response = client.post(path: sub_path, body: batch_report_body(report_data))
+
+        response = ensure_record_key_exists(response)
+        response = add_messages_to_response(response)
+
+        response
       end
 
       private
 
-      def add_messages_to_response(response)
-        # bambora can return null or empty record results, don't decorate with messages
+      def ensure_record_key_exists(response)
+        # bambora can return null or empty record results, fill it in for consistency
         response.dig(:response)[:record] = [] if response.dig(:response, :record).nil?
 
+        response
+      end
+
+      def add_messages_to_response(response)
         response.dig(:response, :record).map! do |record|
           record.merge!(messages: record[:messageId].split(',').map { |id| MESSAGES[id] })
         end

--- a/lib/bambora/client/version.rb
+++ b/lib/bambora/client/version.rb
@@ -2,6 +2,6 @@
 
 module Bambora
   class Client
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/spec/bambora/bank/batch_report_resource_spec.rb
+++ b/spec/bambora/bank/batch_report_resource_spec.rb
@@ -224,7 +224,7 @@ module Bambora
           end
         end
 
-        context 'with nil records' do
+        context 'with nil record' do
           let(:response_body) do
             {
               response: {

--- a/spec/bambora/bank/batch_report_resource_spec.rb
+++ b/spec/bambora/bank/batch_report_resource_spec.rb
@@ -247,11 +247,12 @@ module Bambora
                 records: {
                   total: 0,
                 },
+                record: [],
               },
             }
           end
 
-          it 'returns the expected response' do
+          it 'ensures return contains an :record key' do
             expect(reports.show(request_data)).to eq expected_response
           end
         end


### PR DESCRIPTION
**Description**

This PR ensures the response object from `BatchReportResource#show` always contains a `:record` key. If none exists in the response from Bambora, the response is decorated with `record: []`.

As the middleware between the Bambora API and the caller, it is simple for us to make Bambora API consumption here easier for the client.

**What To Test**

+ [x] CI passes