### PR TITLE
Implement method to update a credit card and bank account payment profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.1 (2020-05-27)
+## 0.3.0 (2020-05-27)
 
 - Add `Bambora::V1::ProfileResource#update` method
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1 (2020-05-27)
+
+- Add `Bambora::V1::ProfileResource#update` method
+
 ## 0.2.0 (2020-05-11)
 
 - Add `Bambora::V1::ProfileResource#get` method

--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ profiles.delete(customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A')
 #    }
 ```
 
+### Update a Profile
+
+```ruby
+profiles.update(
+  customer_code: '02355E2e58Bf488EAB4EaFAD7083dB6A',
+  payment_profile_data: {
+    language: 'en',
+    comments: 'hello',
+    card: {
+      name: 'Hup Podling',
+      number: '4030000010001234',
+      expiry_month: '12',
+      expiry_year: '23',
+      cvd: '123',
+    },
+  },
+)
+
+# => {
+#      :code => 1,
+#      :message => "Operation Successful",
+#      :customer_code => "02355E2e58Bf488EAB4EaFAD7083dB6A",
+#    }
+```
+
 ### Payments
 
 *Summary*: Process payments using Credit Card, Payment Profile, Legato Token, Cash, Cheque, Interac, Apple Pay, or

--- a/lib/bambora/client/version.rb
+++ b/lib/bambora/client/version.rb
@@ -2,6 +2,6 @@
 
 module Bambora
   class Client
-    VERSION = '0.2.1'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/bambora/client/version.rb
+++ b/lib/bambora/client/version.rb
@@ -2,6 +2,6 @@
 
 module Bambora
   class Client
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/lib/bambora/rest/client.rb
+++ b/lib/bambora/rest/client.rb
@@ -38,6 +38,10 @@ module Bambora
         end
       end
 
+      def put(path:, body:, headers:)
+        connection.put(path, body, headers)
+      end
+
       def connection
         @connection ||= Faraday.new(url: base_url) do |faraday|
           faraday.request :multipart

--- a/lib/bambora/rest/json_client.rb
+++ b/lib/bambora/rest/json_client.rb
@@ -99,6 +99,55 @@ module Bambora
         ).to_h
       end
 
+      # Make a PUT Request.
+      #
+      # @example
+      #
+      #   client = Bambora::Rest::JSONClient(base_url: '...', merchant_id: '...')
+      #
+      #   data = {
+      #     billing: {
+      #        name: "joh doe",
+      #        address_line1: "123 main st",
+      #        address_line2: "111",
+      #        city: "victoria",
+      #        province: "bc",
+      #        country: "ca",
+      #        postal_code: "V8T4M3",
+      #        phone_number: "25012312345",
+      #        email_address: "bill@smith.com"
+      #     },
+      #     card: {
+      #       name: 'Hup Podling',
+      #       number: '4030000010001234',
+      #       expiry_month: '12',
+      #       expiry_year: '23',
+      #       cvd: '123',
+      #     },
+      #   }
+      #
+      #   client.put(
+      #     path: 'v1/profiles',
+      #     body: data,
+      #     api_key: '...'
+      #   )
+      #   # => {
+      #   #      :code => 1,
+      #   #      :message => "Operation Successful",
+      #   #      :customer_code => "02355E2e58Bf488EAB4EaFAD7083dB6A",
+      #   #    }
+      #
+      # @param path [String] Indicating request path.
+      # @param body [Hash] Data to be sent in the body of the request.
+      # @param api_key [String] Indicating the API Key to be used with the request.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      def put(path:, body:, api_key:)
+        parse_response_body(
+          super(path: path, body: body.to_json.to_s, headers: build_headers(api_key: api_key)),
+        ).to_h
+      end
+
       private
 
       def build_headers(api_key:)

--- a/lib/bambora/v1/profile_resource.rb
+++ b/lib/bambora/v1/profile_resource.rb
@@ -106,6 +106,7 @@ module Bambora
       #
       #   client = Bambora::Rest::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
       #   profiles = Bambora::V1::ProfileResource(client: client)
+      #   customer_code = '02355E2e58Bf488EAB4EaFAD7083dB6A'
       #
       #   data = {
       #     billing: {
@@ -128,20 +129,15 @@ module Bambora
       #     },
       #   }
       #
-      #   profiles.update(
-      #     path: 'v1/profiles',
-      #     body: data,
-      #     api_key: '...'
-      #   )
+      #   profiles.update(customer_code: customer_code, payment_profile_data: data)
       #   # => {
       #   #      :code => 1,
       #   #      :message => "Operation Successful",
       #   #      :customer_code => "02355E2e58Bf488EAB4EaFAD7083dB6A",
       #   #    }
       #
-      # @param path [String] Indicating request path.
-      # @param body [Hash] Data to be sent in the body of the request.
-      # @param api_key [String] Indicating the API Key to be used with the request.
+      # @param customer_code [String] A unique identifier for the associated payment profile.
+      # @param data [Hash] Payment profile data to be sent in the body of the request.
       #
       # @return [Hash] Indicating success or failure of the operation.
       def update(customer_code:, payment_profile_data:)

--- a/lib/bambora/v1/profile_resource.rb
+++ b/lib/bambora/v1/profile_resource.rb
@@ -54,8 +54,8 @@ module Bambora
       # @see https://dev.na.bambora.com/docs/guides/payment_profiles
       #
       # @return [Hash] Indicating success or failure of the operation.
-      def create(card_data)
-        client.post(path: sub_path, body: card_data, api_key: api_key)
+      def create(payment_profile_data)
+        client.post(path: sub_path, body: payment_profile_data, api_key: api_key)
       end
 
       ##
@@ -98,6 +98,54 @@ module Bambora
       # @return [Hash] Payment profile details.
       def get(customer_code:)
         client.get(path: "#{sub_path}/#{customer_code}", api_key: api_key)
+      end
+
+      # Make a PUT Request.
+      #
+      # @example
+      #
+      #   client = Bambora::Rest::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   profiles = Bambora::V1::ProfileResource(client: client)
+      #
+      #   data = {
+      #     billing: {
+      #        name: "joh doe",
+      #        address_line1: "123 main st",
+      #        address_line2: "111",
+      #        city: "victoria",
+      #        province: "bc",
+      #        country: "ca",
+      #        postal_code: "V8T4M3",
+      #        phone_number: "25012312345",
+      #        email_address: "bill@smith.com"
+      #     },
+      #     card: {
+      #       name: 'Hup Podling',
+      #       number: '4030000010001234',
+      #       expiry_month: '12',
+      #       expiry_year: '23',
+      #       cvd: '123',
+      #     },
+      #   }
+      #
+      #   profiles.update(
+      #     path: 'v1/profiles',
+      #     body: data,
+      #     api_key: '...'
+      #   )
+      #   # => {
+      #   #      :code => 1,
+      #   #      :message => "Operation Successful",
+      #   #      :customer_code => "02355E2e58Bf488EAB4EaFAD7083dB6A",
+      #   #    }
+      #
+      # @param path [String] Indicating request path.
+      # @param body [Hash] Data to be sent in the body of the request.
+      # @param api_key [String] Indicating the API Key to be used with the request.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      def update(customer_code:, payment_profile_data:)
+        client.put(path: "#{@sub_path}/#{customer_code}", body: payment_profile_data, api_key: api_key)
       end
 
       ##

--- a/spec/bambora/rest/json_client_spec.rb
+++ b/spec/bambora/rest/json_client_spec.rb
@@ -14,6 +14,7 @@ module Bambora
       let(:response_body) { { response: 'body', with: { objects: 'yay!' }, and: [{ arrays: 'wow!' }] } }
       let(:failed_status) { 500 }
       let(:failed_response_body) { 'Mouldy mildew, mother of mouthmuck, dangle and strangle and death.' }
+      let(:request_body) { { gelfling: 'Deet' } }
 
       subject { described_class.new(base_url: base_url, merchant_id: merchant_id) }
 
@@ -46,8 +47,6 @@ module Bambora
       end
 
       describe '#post' do
-        let(:request_body) { { gelfling: 'Deet' } }
-
         context 'server responds with a 2xx status' do
           before do
             stub_request(:post, base_url)
@@ -72,6 +71,34 @@ module Bambora
 
           it 'it returns a hash' do
             resp = subject.post(path: path, body: request_body, api_key: api_key)
+            expect(resp).to eq(status: failed_status, body: failed_response_body)
+          end
+        end
+      end
+
+      describe '#put' do
+        context 'server responds with a 2xx status' do
+          before do
+            stub_request(:put, base_url)
+              .with(headers: headers, body: request_body)
+              .to_return(headers: response_headers, body: response_body.to_json.to_s)
+          end
+
+          it 'parses the response' do
+            resp = subject.put(path: path, body: request_body, api_key: api_key)
+            expect(resp).to eq response_body
+          end
+        end
+
+        context 'server responds with a non 2xx status' do
+          before do
+            stub_request(:put, base_url)
+              .with(headers: headers, body: request_body)
+              .to_return(headers: response_headers, body: failed_response_body, status: failed_status)
+          end
+
+          it 'it returns a hash' do
+            resp = subject.put(path: path, body: request_body, api_key: api_key)
             expect(resp).to eq(status: failed_status, body: failed_response_body)
           end
         end

--- a/spec/bambora/v1/profile_resource_spec.rb
+++ b/spec/bambora/v1/profile_resource_spec.rb
@@ -102,7 +102,6 @@ module Bambora
       end
 
       describe '#update' do
-
         let(:customer_code) { 'asdf1234' }
         let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5' } }
         let(:data) do
@@ -123,7 +122,7 @@ module Bambora
               country: 'ca',
               postal_code: 'V8T4M3',
               phone_number: '25012312345',
-              email_address: 'bill@smith.com'
+              email_address: 'bill@smith.com',
             },
           }
         end

--- a/spec/bambora/v1/profile_resource_spec.rb
+++ b/spec/bambora/v1/profile_resource_spec.rb
@@ -101,6 +101,60 @@ module Bambora
         end
       end
 
+      describe '#update' do
+
+        let(:customer_code) { 'asdf1234' }
+        let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5' } }
+        let(:data) do
+          {
+            card: {
+              name: 'Hup Podling',
+              number: '4030000010001234',
+              expiry_month: '12',
+              expiry_year: '23',
+              cvd: '123',
+            },
+            billing: {
+              name: 'john doe',
+              address_line1: '123 main st',
+              address_line2: '111',
+              city: 'victoria',
+              province: 'bc',
+              country: 'ca',
+              postal_code: 'V8T4M3',
+              phone_number: '25012312345',
+              email_address: 'bill@smith.com'
+            },
+          }
+        end
+
+        let(:response_body) do
+          {
+            code: 1,
+            card: {},
+            billing: {},
+          }
+        end
+
+        before do
+          stub_request(:put, "#{base_url}/v1/profiles/#{customer_code}").with(
+            body: data.to_json.to_s,
+            headers: headers,
+          ).to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        it 'posts to the bambora api' do
+          subject.update(customer_code: customer_code, payment_profile_data: data)
+
+          expect(
+            a_request(:put, "#{base_url}/v1/profiles/#{customer_code}").with(
+              body: data.to_json.to_s,
+              headers: headers,
+            ),
+          ).to have_been_made.once
+        end
+      end
+
       describe '#delete' do
         let(:customer_code) { 'asdf1234' }
 


### PR DESCRIPTION
**Description**

This PR implements an `#update` method for the `ProfileResource` to update a payment profile. This works for both **credit card** and **bank account** payment profiles.

I tested this via the console:
- For credit card and billing address information updates I could verify by doing a `get` on the payment profile.
- For bank account information update, I logged into the bambora portal to see if the bank account information in the profile had been updated or not.

**What To Test**

+ [x] Can update a payment profile

**Deployment Instructions**

+ No action required