### PR TITLE
Add missing methods to PaymentResource and ProfileResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+- Add `Bambora::V1::PaymentResource#return_payment` method
+- Add `Bambora::V1::PaymentResource#void` method
+- Add `Bambora::V1::PaymentResource#complete_preauth` method
+
+- Add `Bambora::V1::ProfileResource#add_profile_card` method
+- Add `Bambora::V1::ProfileResource#get_profile_cards` method
+- Add `Bambora::V1::ProfileResource#update_profile_card` method
+- Add `Bambora::V1::ProfileResource#delete_profile_card` method
+
 ## 0.5.0 (2023-01-04)
 
 - Updating minimum Ruby version to Ruby 2.6.6

--- a/lib/bambora/v1/payment_resource.rb
+++ b/lib/bambora/v1/payment_resource.rb
@@ -78,6 +78,71 @@ module Bambora
 
       alias make_payment_with_payment_profile create_with_payment_profile
 
+      # Return payment.
+      #
+      # @example
+      #
+      #   client = Bambora::Rest::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   payments = Bambora::V1::PaymentResource(client: client)
+      #   payments.return_payment(
+      #     transaction_id: 1000341, amount: 50
+      #   )
+      #
+      # @param transaction_id [Integer] The transaction id
+      # @param amount [Float] A decimal value in dollars. Must be less than or equal to the original purchase amount.
+      # @param order_number [String] (Optional) A unique order number.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      def return_payment(transaction_id:, amount:, order_number: nil)
+        data = { amount: amount, order_number: order_number }.compact
+        client.post(path: "#{sub_path}/#{transaction_id}/returns", body: data, api_key: api_key)
+      end
+
+      # Void a transaction. You can void payments, returns, pre-auths, and completions. It will
+      # cancel that transaction.
+      #
+      # @example
+      #
+      #   client = Bambora::Rest::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   payments = Bambora::V1::PaymentResource(client: client)
+      #   payments.void_payment(
+      #     transaction_id: 1000341, amount: 50
+      #   )
+      #
+      # @param transaction_id [Integer] The transaction id to void.
+      # @param amount [Float] A decimal value in dollars. Must be equal to the original purchase amount. You can void purchases as well as pre-auths and returns.
+      # @param order_number [String] (Optional) A unique order number.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      def void(transaction_id:, amount:, order_number: nil)
+        data = { amount: amount, order_number: order_number }.compact
+        client.post(path: "#{sub_path}/#{transaction_id}/void", body: data, api_key: api_key)
+      end
+
+      alias void_payment void
+
+      # Complete a pre-authorized payment. The amount of the transaction to complete must be less
+      # than or equal to the original pre-auth amount.
+      #
+      # @example
+      #
+      #   client = Bambora::Rest::JSONClient(base_url: '...', api_key: '...', merchant_id: '...')
+      #   payments = Bambora::V1::PaymentResource(client: client)
+      #   payments.complete_preauth(
+      #     transaction_id: 1000341, amount: 50
+      #   )
+      #
+      # @param transaction_id [Integer] An integer identifier for the associated transaction.
+      # @param amount [Float] A decimal value in dollars. Uses up to two decimal places. Max value is account specific.
+      #   Default max value is 1000.
+      # @param order_number [String] (Optional) A unique order number.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      def complete_preauth(transaction_id:, amount:, order_number: nil)
+        data = { amount: amount, order_number: order_number }.compact
+        client.post(path: "#{sub_path}/#{transaction_id}/completions", body: data, api_key: api_key)
+      end
+
       # Retrieve the details of a previously attempted payment.
       #
       #

--- a/lib/bambora/v1/profile_resource.rb
+++ b/lib/bambora/v1/profile_resource.rb
@@ -49,7 +49,7 @@ module Bambora
       #   #      :customer_code => "02355E2e58Bf488EAB4EaFAD7083dB6A",
       #   #    }
       #
-      # @param card_data [Hash] All information relevant to making a payment.
+      # @param payment_profile_data [Hash] All information relevant to making a payment.
       #
       # @see https://dev.na.bambora.com/docs/guides/payment_profiles
       #
@@ -137,7 +137,7 @@ module Bambora
       #   #    }
       #
       # @param customer_code [String] A unique identifier for the associated payment profile.
-      # @param data [Hash] Payment profile data to be sent in the body of the request.
+      # @param payment_profile_data [Hash] Payment profile data to be sent in the body of the request.
       #
       # @return [Hash] Indicating success or failure of the operation.
       def update(customer_code:, payment_profile_data:)
@@ -165,6 +165,54 @@ module Bambora
       # @return [Hash] Indicating success or failure of the operation.
       def delete(customer_code:)
         client.delete(path: "#{@sub_path}/#{customer_code}", api_key: api_key)
+      end
+
+      # Add a card to the specified payment profile.
+      #
+      # @param customer_code [String] A unique identifier for the associated payment profile.
+      # @param data [Hash] Card data to be sent in the body of the request.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      #
+      # @see https://dev.na.bambora.com/docs/guides/payment_profiles/#add-a-card
+      def add_profile_card(customer_code:, data:)
+        client.post(path: "#{sub_path}/#{customer_code}/cards", body: data, api_key: api_key)
+      end
+
+      # Get a list of cards associated with the specified payment profile.
+      #
+      # @param customer_code [String] A unique identifier for the associated payment profile.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      #
+      # @see https://dev.na.bambora.com/docs/guides/payment_profiles/#retrieve-cards
+      def get_profile_cards(customer_code:)
+        client.get(path: "#{sub_path}/#{customer_code}/cards", api_key: api_key)
+      end
+
+      # Update the card expiry fields for a card in the given profile.
+      #
+      # @param customer_code [String] A unique identifier for the associated payment profile.
+      # @param card_id [Integer] The card id to update.
+      # @param data [Hash] Card data to be sent in the body of the request.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      #
+      # @see https://dev.na.bambora.com/docs/guides/payment_profiles/#update-a-card
+      def update_profile_card(customer_code:, card_id:, data:)
+        client.put(path: "#{sub_path}/#{customer_code}/cards/#{card_id}", body: data, api_key: api_key)
+      end
+
+      # Delete a card from the specified payment profile.
+      #
+      # @param customer_code [String] A unique identifier for the associated payment profile.
+      # @param card_id [Integer] The card id to delete.
+      #
+      # @return [Hash] Indicating success or failure of the operation.
+      #
+      # @see https://dev.na.bambora.com/docs/guides/payment_profiles/#delete-a-card
+      def delete_profile_card(customer_code:, card_id:)
+        client.delete(path: "#{@sub_path}/#{customer_code}/cards/#{card_id}", api_key: api_key)
       end
     end
   end

--- a/spec/bambora/v1/payment_resource_spec.rb
+++ b/spec/bambora/v1/payment_resource_spec.rb
@@ -179,6 +179,93 @@ module Bambora
         end
       end
 
+      describe '#return_payment' do
+        before(:each) do
+          stub_request(:post, "#{base_url}/v1/payments/#{transaction_id}/returns").with(
+            body: data.to_json.to_s,
+            headers: headers,
+          ).to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        let(:transaction_id) { 1_000_001 }
+        let(:data) do
+          {
+            amount: 50,
+          }
+        end
+
+        it "POST's to the Bambora API" do
+          subject.return_payment(transaction_id: transaction_id, amount: 50)
+
+          expect(
+            a_request(:post, "#{base_url}/v1/payments/#{transaction_id}/returns").with(
+              body: data.to_json.to_s,
+              headers: headers,
+            ),
+          ).to have_been_made.once
+        end
+      end
+
+      describe '#void' do
+        before(:each) do
+          stub_request(:post, "#{base_url}/v1/payments/#{transaction_id}/void").with(
+            body: data.to_json.to_s,
+            headers: headers,
+          ).to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        let(:transaction_id) { 1_000_001 }
+        let(:data) do
+          {
+            amount: 50,
+          }
+        end
+
+        it "POST's to the Bambora API" do
+          subject.void(transaction_id: transaction_id, amount: 50)
+
+          expect(
+            a_request(:post, "#{base_url}/v1/payments/#{transaction_id}/void").with(
+              body: data.to_json.to_s,
+              headers: headers,
+            ),
+          ).to have_been_made.once
+        end
+      end
+
+      describe '#void_payment' do
+        it 'is an alias of #void' do
+          expect(subject.method(:void_payment)).to eq(subject.method(:void))
+        end
+      end
+
+      describe '#complete_preauth' do
+        before(:each) do
+          stub_request(:post, "#{base_url}/v1/payments/#{transaction_id}/completions").with(
+            body: data.to_json.to_s,
+            headers: headers,
+          ).to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        let(:transaction_id) { 1_000_001 }
+        let(:data) do
+          {
+            amount: 50,
+          }
+        end
+
+        it "POST's to the Bambora API" do
+          subject.complete_preauth(transaction_id: transaction_id, amount: 50)
+
+          expect(
+            a_request(:post, "#{base_url}/v1/payments/#{transaction_id}/completions").with(
+              body: data.to_json.to_s,
+              headers: headers,
+            ),
+          ).to have_been_made.once
+        end
+      end
+
       describe '#get' do
         let(:transaction_id) { 1_000_001 }
         let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5' } }

--- a/spec/bambora/v1/profile_resource_spec.rb
+++ b/spec/bambora/v1/profile_resource_spec.rb
@@ -173,6 +173,150 @@ module Bambora
           ).to have_been_made.once
         end
       end
+
+      describe '#add_profile_card' do
+        let(:customer_code) { 'asdf1234' }
+        let(:data) do
+          {
+						token: {  
+							name:"John Doe",
+							code:"1eCe9480a7D94919997071a483505D17",
+						},
+          }
+        end
+
+        before do
+          stub_request(:post, "#{base_url}/v1/profiles/#{customer_code}/cards").with(
+            body: data.to_json.to_s,
+            headers: headers,
+          ).to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        it 'posts to the bambora api' do
+          subject.add_profile_card(customer_code: customer_code, data: data)
+
+          expect(
+            a_request(:post, "#{base_url}/v1/profiles/#{customer_code}/cards").with(
+              body: data.to_json.to_s,
+              headers: headers,
+            ),
+          ).to have_been_made.once
+        end
+      end
+
+      describe '#get' do
+        before do
+          stub_request(:get, "#{base_url}/v1/profiles/#{customer_code}")
+            .with(headers: headers)
+            .to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        let(:customer_code) { 'asdf1234' }
+        let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5' } }
+        let(:response_body) do
+          {
+            code: 1,
+            card: {},
+            billing: {},
+          }
+        end
+
+        it 'performs GET request for profile data' do
+          subject.get(customer_code: customer_code)
+
+          expect(
+            a_request(:get, "#{base_url}/v1/profiles/#{customer_code}")
+              .with(headers: headers),
+          ).to have_been_made.once
+        end
+      end
+
+      describe '#get_profile_cards' do
+        before do
+          stub_request(:get, "#{base_url}/v1/profiles/#{customer_code}/cards")
+            .with(headers: headers)
+            .to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        let(:customer_code) { 'asdf1234' }
+        let(:headers) { { 'Authorization' => 'Passcode MTpmYWtla2V5' } }
+        let(:response_body) do
+          {
+            code: 1,
+						message: "Operation Successful",
+						customer_code: 'aaa111',
+            card: [{
+              card_id: '1',
+              function: 'DEF',
+              name: 'Hup Podling',
+              number: '4030000010001234',
+              expiry_month: '12',
+              expiry_year: '23',
+              card_type: 'VI'
+            }],
+          }
+        end
+
+        it 'performs GET request for profile data' do
+          subject.get_profile_cards(customer_code: customer_code)
+
+          expect(
+            a_request(:get, "#{base_url}/v1/profiles/#{customer_code}/cards")
+              .with(headers: headers),
+          ).to have_been_made.once
+        end
+      end
+
+      describe '#update_profile_card' do
+        let(:customer_code) { 'asdf1234' }
+        let(:card_id) { 128 }
+
+        let(:data) do
+          {
+            card: {
+              expiry_month: '12',
+              expiry_year: '25',
+            },
+          }
+        end
+
+        before do
+          stub_request(:put, "#{base_url}/v1/profiles/#{customer_code}/cards/#{card_id}")
+            .with(headers: headers)
+            .to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        it 'posts to the bambora api' do
+          subject.update_profile_card(customer_code: customer_code, card_id: card_id, data: data)
+
+          expect(
+            a_request(:put, "#{base_url}/v1/profiles/#{customer_code}/cards/#{card_id}").with(
+              headers: headers,
+            ),
+          ).to have_been_made.once
+        end
+      end
+
+      describe '#delete_profile_card' do
+        let(:customer_code) { 'asdf1234' }
+        let(:card_id) { 128 }
+
+        before do
+          stub_request(:delete, "#{base_url}/v1/profiles/#{customer_code}/cards/#{card_id}")
+            .with(headers: headers)
+            .to_return(headers: response_headers, body: response_body.to_json.to_s)
+        end
+
+        it 'posts to the bambora api' do
+          subject.delete_profile_card(customer_code: customer_code, card_id: card_id)
+
+          expect(
+            a_request(:delete, "#{base_url}/v1/profiles/#{customer_code}/cards/#{card_id}").with(
+              headers: headers,
+            ),
+          ).to have_been_made.once
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add missing methods from https://dev.na.bambora.com/docs/references/payment_APIs/v1-0-5/ 
- Add `Bambora::V1::PaymentResource#return_payment` method
- Add `Bambora::V1::PaymentResource#void` method
- Add `Bambora::V1::PaymentResource#complete_preauth` method

Add missing methods from https://dev.na.bambora.com/docs/guides/payment_profiles/
- Add `Bambora::V1::ProfileResource#add_profile_card` method
- Add `Bambora::V1::ProfileResource#get_profile_cards` method
- Add `Bambora::V1::ProfileResource#update_profile_card` method
- Add `Bambora::V1::ProfileResource#delete_profile_card` method