### PR TITLE
[RIS-1259] Fix errors raised by gem builder

### DIFF
--- a/bambora-client.gemspec
+++ b/bambora-client.gemspec
@@ -6,8 +6,8 @@ require 'bambora/client/version'
 Gem::Specification.new do |spec|
   spec.name          = 'bambora-client'
   spec.version       = Bambora::Client::VERSION
-  spec.authors       = ['Cassidy K']
-  spec.email         = ['hello@cassidy.codes', 'tech@himama.com']
+  spec.authors       = ['HiMama']
+  spec.email         = ['tech@himama.com']
 
   spec.summary       = 'A thread-safe client for the Bambora/Beanstream API.'
   spec.description   = 'The official beanstream-ruby gem is not thread-safe. This thread-safe client works in '\
@@ -40,14 +40,14 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0.5'
 
   spec.add_dependency 'faraday', '~> 2.0.1'
-  spec.add_dependency 'faraday-excon'
-  spec.add_dependency 'faraday-multipart'
+  spec.add_dependency 'faraday-excon', '~> 2.1.0'
+  spec.add_dependency 'faraday-multipart', '~> 1.0.0'
   spec.add_dependency 'gyoku', '~> 1.0'
   spec.add_dependency 'multiparty', '~> 0'
 
   spec.add_development_dependency 'bundler', '~> 2'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'pry', '~> 0.14.0'
+  spec.add_development_dependency 'pry-byebug', '~> 3.8.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'


### PR DESCRIPTION
On preparing `v0.7.0` for release to Rubygems, I was prompted to fix the package requirements. 

Pinning versions to satisfy bundler, and updating some details in `gemspec` so our authorship is referenced.

**Screenshots**

Before
<img width="625" alt="image" src="https://github.com/HiMamaInc/bambora-client/assets/61441409/3340299f-5f14-4b5d-a09b-c5b91a8074da">

After
<img width="550" alt="image" src="https://github.com/HiMamaInc/bambora-client/assets/61441409/6c312dd4-b1d9-4d0b-a49e-4c049e901ceb">
